### PR TITLE
Fix plot_pump_traj IndexError (#17/#25), add QuantumGraph class (#28), decouple per-mode D0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,10 +79,12 @@ mapping.
 ## Conventions
 
 - Black, line length 100. `pycodestyle` ignores `W503,E731,W605,E203`.
-- Parameters live in `graph.graph["params"]` — a single mutable dict that
-  worker classes also mutate (`WorkerModes.set_search_radii`). Be careful when
-  editing: pool workers pickle the graph, so per-call mutation does not leak
-  across processes, but in-process mutation does.
+- Parameters live in `graph.graph["params"]` (a `NetSaltParams` model).
+  Per-mode pump (`D0`) and search-window overrides are applied to a throwaway
+  graph + params copy (`graph_with_pump`, `WorkerModes.__call__`) rather than
+  mutated in place, so the shared params are not modified during a compute.
+  Pool workers still pickle the graph, so even per-call mutation would not leak
+  across processes — but the copy keeps the in-process graph clean too.
 - `to_complex(mode) == mode[0] - 1j*mode[1]` (note the **minus** sign: alpha is
   stored as `-imag(k)`). Keep this sign convention.
 - RNG: compute functions accept an `rng=` kwarg (a
@@ -192,13 +194,18 @@ they are what an "old code" most needs before further work lands on top.
 
 ## Known design debt (follow-up PRs)
 
-- ``WorkerModes`` still mutates ``graph.graph["params"]`` in place to
-  stash the current ``D0`` and search window. Downstream consumers
-  (``mode_on_nodes``, ``pump_linear``, the dispersion relations) read
-  those fields back off the graph to reconstruct the laplacian at the
-  right ``D0``, so decoupling requires carrying ``(mode, D0)`` pairs
-  explicitly through the modes dataframe — tracked as architectural
-  debt rather than a quick fix.
+- ~~``WorkerModes`` mutates ``graph.graph["params"]`` in place to stash
+  the current ``D0`` and search window.~~ **Done.** The per-mode pump and
+  search window are now applied to a throwaway graph + params copy
+  (``graph_with_pump`` in ``quantum_graph.py``, used by
+  ``WorkerModes.__call__``, ``pump_linear``,
+  ``_precomputations_mode_competition``, ``lasing_threshold_linear``, and
+  the ``plotting.py`` lasing-mode helpers). The shared ``params`` are no
+  longer modified during a compute; downstream consumers
+  (``mode_on_nodes``, the dispersion relations, the ``graph.graph["ks"]``
+  read-backs) operate on the local copy so the laplacian is still built at
+  the right ``D0``. Behaviour is unchanged (the functional test passes
+  byte-identical).
 - Compute-core tests are still fairly shallow. Adding a test for
   ``compute_mode_competition_matrix`` and ``find_threshold_lasing_modes``
   on a tiny analytic graph would give more regression coverage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,8 @@ they are what an "old code" most needs before further work lands on top.
    arrays, complex numbers, `NetSaltParams`, and registered dispersion
    relations. Pickle still works on `.pkl`/`.gpickle` filenames but
    requires an explicit `allow_pickle=True` on load; otherwise the call
-   raises, and save emits a `DeprecationWarning`. Luigi defaults and test
-   fixtures updated to `.json`.
+   raises, and save emits a `DeprecationWarning`. Pipeline defaults and
+   test fixtures use `.json`.
 
 5. ~~**Global `np.random.seed(42)` calls.**~~ **Done.** All `np.random.seed`
    calls in the package are gone. `laplacian_quality`, `mode_quality`,

--- a/README.md
+++ b/README.md
@@ -38,18 +38,19 @@ pip install netsalt
 
 ## Usage
 
-The code is accessible directly, or via a workflow manager (luigi) and related configuration files, see `examples/`.
+The code is accessible directly, or via a plain-Python pipeline
+(`netsalt.pipeline`) driven by YAML config files, see `examples/`.
 
 ### Mode search
 
 Modes inside a complex-`k` rectangle can be located three different
-ways. The Luigi pipeline picks one via
+ways. The pipeline picks one via
 `params["mode_search_method"]` (default `"contour"`); direct callers
 can pick by importing the function they want.
 
-| entry point | when to use | wired into Luigi? |
+| entry point | when to use | wired into the pipeline? |
 |---|---|---|
-| `find_modes_contour` | the production search; takes an `n_k × n_alpha` cell layout | **yes** — used by `find_passive_modes(method="contour")`, the Luigi default |
+| `find_modes_contour` | the production search; takes an `n_k × n_alpha` cell layout | **yes** — used by `find_passive_modes(method="contour")`, the pipeline default |
 | `find_modes_contour_adaptive` | parameter discovery — you don't know the mode count yet | no — direct API only |
 | `tune_contour_parameters` | batches of similar-density randomized graphs | no — direct API only |
 
@@ -62,10 +63,10 @@ explicit `n_k`, picked either by hand from the rule
 `n_k ≥ ⌈expected_modes / (0.65 · probe_dim)⌉` or by
 `tune_contour_parameters`.
 
-#### The Luigi default
+#### The pipeline default
 
-`luigi.cfg` has `mode_search_method = contour`, which routes
-`FindPassiveModes` (`netsalt/tasks/passive.py`) through
+`config.yaml` has `mode_search_method = contour`, which routes
+`step_find_passive_modes` (`netsalt/pipeline.py`) through
 `netsalt.find_passive_modes(method="contour")` →
 `find_modes_contour`. Sensible defaults are picked from
 `graph.graph["params"]`:
@@ -110,10 +111,9 @@ deep recursion can drop modes near cell edges. If 100% coverage
 matters, use `find_modes_contour` with an explicit `n_k` instead —
 preferably one that `tune_contour_parameters` picked for you.
 
-The adaptive search is not currently wired into `FindPassiveModes`;
-if you want it inside a Luigi run, call it from a custom
-`NetSaltTask` subclass and write the resulting modes to the
-`passive_modes_path` output.
+The adaptive search is not currently wired into
+`step_find_passive_modes`; if you want it inside a pipeline run, call
+it directly and write the resulting modes to the passive-modes output.
 
 #### Batch processing similar graphs (`tune_contour_parameters`)
 
@@ -151,7 +151,7 @@ recommended `n_k` recovers them all (the stress workload in
 
 #### When to choose what
 
-- **Default Luigi run** (`mode_search_method = contour`) is fine
+- **Default pipeline run** (`mode_search_method = contour`) is fine
   for most workloads — it picks `n_k ≈ k_range` and the netsalt
   scan rectangles are small enough that this is well-sized.
 - **Use `tune_contour_parameters`** when running the same search

--- a/README.md
+++ b/README.md
@@ -41,6 +41,59 @@ pip install netsalt
 The code is accessible directly, or via a plain-Python pipeline
 (`netsalt.pipeline`) driven by YAML config files, see `examples/`.
 
+### Quickstart
+
+**The object API.** `QuantumGraph` is a thin `networkx.Graph` subclass that
+carries the quantum-graph state and exposes the build/solve helpers as methods,
+so you set up physics and build matrices on one object instead of threading a
+bare graph through free functions:
+
+```python
+import networkx as nx
+import numpy as np
+from netsalt import QuantumGraph
+from netsalt.physics import dispersion_relation_dielectric
+
+g = nx.path_graph(20)
+positions = np.array([[float(i), 0.0] for i in range(20)])
+
+qg = QuantumGraph.from_networkx(
+    g,
+    params={
+        "open_model": "open",
+        "c": 1.0,
+        "dielectric_params": {
+            "method": "uniform",
+            "inner_value": 4.0,
+            "loss": 0.0,
+            "outer_value": 1.0,
+        },
+    },
+    positions=positions,
+)
+qg.set_dispersion_relation(dispersion_relation_dielectric)
+qg.set_dielectric_constant()
+
+L = qg.laplacian(2.0 + 0.0j)        # quantum Laplacian L(k)
+quality = qg.mode_quality([2.0, 0.0])  # how close [Re(k), -Im(k)] is to a mode
+pumped = qg.with_pump(0.7)          # a copy at pump D0 = 0.7, original untouched
+```
+
+Every method delegates to the matching module-level function (`construct_laplacian`,
+`mode_quality`, …), so the procedural API keeps working unchanged and the class is
+purely opt-in. `load_graph("graph.json", as_class=True)` returns a `QuantumGraph`.
+
+**The pipeline.** For a full passive/lasing/controllability run, drive the
+pipeline from a YAML config:
+
+```bash
+python -m netsalt lasing config.yaml          # passive | lasing | controllability
+```
+
+Each step caches to disk and is skipped when its output exists (pass `--force`
+to recompute). See `examples/` for ready-to-run configs and `MIGRATION.md` if
+you are coming from the old Luigi workflow.
+
 ### Mode search
 
 Modes inside a complex-`k` rectangle can be located three different

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,19 +11,68 @@
 Installation
 ************
 
-To install the dev version from `GitHub <https://github.com/imperialcollegelondon/hcga/>`_ with the commands::
+We recommend `uv <https://docs.astral.sh/uv/>`_ for managing the environment.
+From a checkout::
 
-       $ git clone git@github.com:ImperialCollegeLondon/netSALT.git
-       $ cd netSALT 
-       $ pip install .
+       $ git clone git@github.com:arnaudon/netSALT.git
+       $ cd netSALT
+       $ uv venv
+       $ uv pip install -e .
 
-There is no PyPi release version yet, but stay tuned for more!
+or from PyPI::
+
+       $ uv pip install netsalt
+
+Plain ``pip`` works too (``pip install -e .`` or ``pip install netsalt``).
 
 
 Usage
 *****
 
-See the folder `example` with the sequence of scripts, from 0 to 0.
+netSALT can be used directly as a library or through a plain-Python pipeline
+driven by YAML config files.
+
+**Object API.** :class:`netsalt.QuantumGraph` is a thin ``networkx.Graph``
+subclass that carries the quantum-graph state and exposes the build/solve
+helpers as methods::
+
+       import networkx as nx
+       import numpy as np
+       from netsalt import QuantumGraph
+       from netsalt.physics import dispersion_relation_dielectric
+
+       g = nx.path_graph(20)
+       positions = np.array([[float(i), 0.0] for i in range(20)])
+       qg = QuantumGraph.from_networkx(
+           g,
+           params={
+               "open_model": "open",
+               "c": 1.0,
+               "dielectric_params": {
+                   "method": "uniform",
+                   "inner_value": 4.0,
+                   "loss": 0.0,
+                   "outer_value": 1.0,
+               },
+           },
+           positions=positions,
+       )
+       qg.set_dispersion_relation(dispersion_relation_dielectric)
+       qg.set_dielectric_constant()
+
+       L = qg.laplacian(2.0 + 0.0j)        # quantum Laplacian L(k)
+       quality = qg.mode_quality([2.0, 0.0])
+
+Each method delegates to the matching module-level function, so the procedural
+API (``construct_laplacian``, ``mode_quality``, …) keeps working unchanged.
+
+**Pipeline.** For a full passive/lasing/controllability run, drive the
+pipeline from a YAML config::
+
+       $ python -m netsalt lasing config.yaml   # passive | lasing | controllability
+
+Each step caches to disk and is skipped when its output already exists (pass
+``--force`` to recompute). See the ``examples`` folder for ready-to-run configs.
 
 Citing
 ******

--- a/doc/source/quantum_graph.rst
+++ b/doc/source/quantum_graph.rst
@@ -1,4 +1,19 @@
 The quantum graph module
 =========================
+
+This module builds a quantum graph from a ``networkx`` graph (edge lengths,
+pumps, dielectric) and constructs the Laplacian / weight / incidence matrices.
+
+The functions here all take a graph as their first argument. For an object-style
+API, :class:`~netsalt.quantum_graph.QuantumGraph` is a thin ``networkx.Graph``
+subclass whose methods (``laplacian``, ``mode_quality``, ``scan_frequencies``,
+``with_pump``, …) delegate to those functions — see
+:meth:`~netsalt.quantum_graph.QuantumGraph.from_networkx` to build one.
+
+Per-pump and per-mode work is done on throwaway copies via
+:func:`~netsalt.quantum_graph.graph_with_params` (and its
+:func:`~netsalt.quantum_graph.graph_with_pump` shortcut) rather than by mutating
+the shared ``graph.graph["params"]`` in place.
+
 .. automodule:: netsalt.quantum_graph
-   :members: 
+   :members:

--- a/netsalt/__init__.py
+++ b/netsalt/__init__.py
@@ -28,6 +28,7 @@ from .modes import (
 from .params import NetSaltParams
 from .physics import set_dielectric_constant, set_dispersion_relation
 from .quantum_graph import (
+    QuantumGraph,
     create_quantum_graph,
     oversample_graph,
     set_total_length,
@@ -37,6 +38,7 @@ from .utils import lorentzian
 
 __all__ = [
     "NetSaltParams",
+    "QuantumGraph",
     "compute_modal_intensities",
     "compute_mode_competition_matrix",
     "create_quantum_graph",

--- a/netsalt/algorithm.py
+++ b/netsalt/algorithm.py
@@ -156,8 +156,8 @@ def _search_box(params):
     """Return the half-width box ``(dk, dα)`` around the initial guess that
     a non-Brownian refiner is allowed to leave before the mode is rejected.
 
-    ``WorkerModes.set_search_radii`` sets ``k_min``/``k_max`` (and the
-    ``alpha_*`` pair) centred on each initial guess. We reuse their half-
+    ``WorkerModes`` sets ``k_min``/``k_max`` (and the ``alpha_*`` pair) on a
+    per-mode params copy, centred on each initial guess. We reuse their half-
     extent here so ``root`` honours the same locality that the Brownian
     ratchet achieves by taking small steps. If no search window is set
     (caller invoking the refiner directly), fall back to the
@@ -172,8 +172,8 @@ def _search_box(params):
     # own basin — looser and neighbouring modes start absorbing each other
     # (``peak_local_max`` keeps local minima at least 2 cells apart, so
     # 1.5 is the largest safe factor). Multiply by 1.5 on top of the
-    # caller's search window, which ``WorkerModes.set_search_radii``
-    # already scales to ~1 grid cell.
+    # caller's search window, which ``WorkerModes`` already scales to
+    # ~1 grid cell.
     return 1.5 * dk, 1.5 * da
 
 

--- a/netsalt/io.py
+++ b/netsalt/io.py
@@ -110,7 +110,7 @@ def save_graph(graph, filename: str = "graph.json") -> None:
         json.dump(payload, json_file, cls=_GraphJSONEncoder)
 
 
-def load_graph(filename: str = "graph.json", *, allow_pickle: bool = False):
+def load_graph(filename: str = "graph.json", *, allow_pickle: bool = False, as_class: bool = False):
     """Load a quantum graph from disk.
 
     Args:
@@ -119,6 +119,11 @@ def load_graph(filename: str = "graph.json", *, allow_pickle: bool = False):
             because unpickling executes arbitrary code in the source file.
         allow_pickle: explicit opt-in for pickle-format files. Only enable
             for files you produced yourself or fully trust.
+        as_class: if True, return a
+            :class:`~netsalt.quantum_graph.QuantumGraph` instead of a plain
+            ``networkx.Graph``. Defaults to False so existing callers are
+            unaffected. Only applies to the JSON path; the pickle path returns
+            whatever type was pickled.
     """
     path = Path(filename)
     if path.suffix in _PICKLE_SUFFIXES:
@@ -154,6 +159,10 @@ def load_graph(filename: str = "graph.json", *, allow_pickle: bool = False):
     params = graph.graph.get("params")
     if params is not None and not isinstance(params, NetSaltParams):
         graph.graph["params"] = NetSaltParams.from_dict(params)
+    if as_class:
+        from .quantum_graph import QuantumGraph  # local import avoids an import cycle
+
+        return QuantumGraph(graph)
     return graph
 
 

--- a/netsalt/modes.py
+++ b/netsalt/modes.py
@@ -53,11 +53,12 @@ def _scoped_warning_filters():
 class WorkerModes:
     """Worker to find modes.
 
-    Note on state: the per-mode pump (``D0``) and search window are applied to
-    a throwaway copy of the graph and its ``params`` inside :meth:`__call__`,
-    so the shared ``graph.graph["params"]`` is never mutated in place. The
-    refiner reads ``D0`` back off that local copy's params when it rebuilds the
-    laplacian, which keeps each mode's computation self-contained.
+    Note on state: the per-mode pump (``D0``), search window, and search
+    stepsize are applied to a throwaway copy of the graph and its ``params``
+    inside :meth:`__call__`, so the shared ``graph.graph["params"]`` is never
+    mutated in place. The refiner reads ``D0`` back off that local copy's
+    params when it rebuilds the laplacian, which keeps each mode's computation
+    self-contained.
     """
 
     def __init__(
@@ -66,6 +67,7 @@ class WorkerModes:
         graph,
         D0s=None,
         search_radii=None,
+        search_stepsize=None,
         seed=42,
         quality_method="eigenvalue",
     ):
@@ -74,6 +76,7 @@ class WorkerModes:
         self.estimated_modes = estimated_modes
         self.D0s = D0s
         self.search_radii = search_radii
+        self.search_stepsize = search_stepsize
         self.seed = seed
         self.quality_method = quality_method
 
@@ -97,15 +100,22 @@ class WorkerModes:
         mode = self.estimated_modes[mode_id]
         graph = self.graph
         params = graph.graph["params"]
-        # Apply the per-mode pump / search window to a throwaway graph + params
-        # copy so the shared graph.graph["params"] is never mutated in place.
-        if self.D0s is not None or self.search_radii is not None:
+        # Apply the per-mode pump / search window / stepsize to a throwaway
+        # graph + params copy so the shared graph.graph["params"] is never
+        # mutated in place.
+        if (
+            self.D0s is not None
+            or self.search_radii is not None
+            or self.search_stepsize is not None
+        ):
             graph = graph.copy()
             params = params.model_copy() if isinstance(params, NetSaltParams) else dict(params)
             if self.D0s is not None:
                 params["D0"] = self.D0s[mode_id]
             if self.search_radii is not None:
                 params.update(self._search_radii_updates(mode))
+            if self.search_stepsize is not None:
+                params["search_stepsize"] = self.search_stepsize
             graph.graph["params"] = params
         # Derive a per-mode seed so each call has an independent RNG stream
         # rather than sharing ``self.seed`` across every mode in the pool.
@@ -982,14 +992,20 @@ def find_threshold_lasing_modes(modes_df, graph, quality_method="eigenvalue"):
                 new_D0s[mode_id] = new_D0
                 new_modes_approx[mode_id] = new_mode_approx
 
-        # this is a trick to reduce the stepsizes as we are near the solution
-        graph.graph["params"]["search_stepsize"] = (
+        # this is a trick to reduce the stepsizes as we are near the solution.
+        # Passed explicitly to WorkerModes (applied to its per-call params copy)
+        # rather than stashed on the shared graph.graph["params"].
+        search_stepsize = (
             stepsize * np.mean(abs(new_D0s[new_D0s > 0] - D0s[new_D0s > 0])) / D0_steps
         )
 
-        L.debug("Current search_stepsize: %s", graph.graph["params"]["search_stepsize"])
+        L.debug("Current search_stepsize: %s", search_stepsize)
         worker_modes = WorkerModes(
-            new_modes_approx, graph, D0s=new_D0s, quality_method=quality_method
+            new_modes_approx,
+            graph,
+            D0s=new_D0s,
+            search_stepsize=search_stepsize,
+            quality_method=quality_method,
         )
         new_modes_tmp = np.zeros([len(modes_df), 2])
 

--- a/netsalt/modes.py
+++ b/netsalt/modes.py
@@ -21,11 +21,13 @@ from .algorithm import (
     find_rough_modes_from_scan,
     refine_mode,
 )
+from .params import NetSaltParams
 from .physics import gamma, q_value
 from .quantum_graph import (
     construct_incidence_matrix,
     construct_laplacian,
     construct_weight_matrix,
+    graph_with_pump,
     mode_quality,
     set_wavenumber,
 )
@@ -51,13 +53,11 @@ def _scoped_warning_filters():
 class WorkerModes:
     """Worker to find modes.
 
-    Note on state: ``self.params`` aliases ``graph.graph["params"]`` and is
-    mutated in place (``D0`` and search-window fields). Several downstream
-    consumers (``mode_on_nodes``, ``pump_linear``, the dispersion relations)
-    read those same fields back off ``graph.graph["params"]`` to reconstruct
-    the laplacian at the right ``D0``. Decoupling that coupling would
-    require carrying ``(mode, D0)`` pairs explicitly through the dataframe
-    — tracked for a follow-up refactor.
+    Note on state: the per-mode pump (``D0``) and search window are applied to
+    a throwaway copy of the graph and its ``params`` inside :meth:`__call__`,
+    so the shared ``graph.graph["params"]`` is never mutated in place. The
+    refiner reads ``D0`` back off that local copy's params when it rebuilds the
+    laplacian, which keeps each mode's computation self-contained.
     """
 
     def __init__(
@@ -71,36 +71,49 @@ class WorkerModes:
     ):
         """Init function of the worker."""
         self.graph = graph
-        self.params = graph.graph["params"]
         self.estimated_modes = estimated_modes
         self.D0s = D0s
         self.search_radii = search_radii
         self.seed = seed
         self.quality_method = quality_method
 
-    def set_search_radii(self, mode):
-        """This fixes a local search region set by search radii."""
-        self.params["k_min"] = mode[0] - self.search_radii[0]
-        self.params["k_max"] = mode[0] + self.search_radii[0]
-        self.params["alpha_min"] = mode[1] - self.search_radii[1]
-        self.params["alpha_max"] = mode[1] + self.search_radii[1]
-        # the 0.1 factor is hardcoded and seems to be a good value
-        self.params["search_stepsize"] = 0.1 * np.linalg.norm(self.search_radii)
+    def _search_radii_updates(self, mode):
+        """Per-mode local search window centred on the initial guess.
+
+        Returned as a dict for the caller to apply to a *local* params copy —
+        deliberately not mutating shared state.
+        """
+        return {
+            "k_min": mode[0] - self.search_radii[0],
+            "k_max": mode[0] + self.search_radii[0],
+            "alpha_min": mode[1] - self.search_radii[1],
+            "alpha_max": mode[1] + self.search_radii[1],
+            # the 0.1 factor is hardcoded and seems to be a good value
+            "search_stepsize": 0.1 * np.linalg.norm(self.search_radii),
+        }
 
     def __call__(self, mode_id):
         """Call function of the worker."""
-        if self.D0s is not None:
-            self.params["D0"] = self.D0s[mode_id]
         mode = self.estimated_modes[mode_id]
-        if self.search_radii is not None:
-            self.set_search_radii(mode)
+        graph = self.graph
+        params = graph.graph["params"]
+        # Apply the per-mode pump / search window to a throwaway graph + params
+        # copy so the shared graph.graph["params"] is never mutated in place.
+        if self.D0s is not None or self.search_radii is not None:
+            graph = graph.copy()
+            params = params.model_copy() if isinstance(params, NetSaltParams) else dict(params)
+            if self.D0s is not None:
+                params["D0"] = self.D0s[mode_id]
+            if self.search_radii is not None:
+                params.update(self._search_radii_updates(mode))
+            graph.graph["params"] = params
         # Derive a per-mode seed so each call has an independent RNG stream
         # rather than sharing ``self.seed`` across every mode in the pool.
         rng = np.random.default_rng([self.seed, mode_id])
         return refine_mode(
             mode,
-            self.graph,
-            self.params,
+            graph,
+            params,
             quality_method=self.quality_method,
             rng=rng,
         )
@@ -387,7 +400,7 @@ def compute_overlapping_factor(passive_mode, graph):
 
 def pump_linear(mode_0, graph, D0_0, D0_1):
     """Find the linear approximation of the new wavenumber."""
-    graph.graph["params"]["D0"] = D0_0
+    graph = graph_with_pump(graph, D0_0)
     overlapping_factor = compute_overlapping_factor(mode_0, graph)
     freq = to_complex(mode_0)
     gamma_overlap = gamma(freq, graph.graph["params"]) * overlapping_factor
@@ -553,7 +566,7 @@ def _precomputations_mode_competition(graph, pump_mask, mode_threshold):
     """precompute some quantities for a mode for mode competition matrix"""
     mode, threshold = mode_threshold
 
-    graph.graph["params"]["D0"] = threshold
+    graph = graph_with_pump(graph, threshold)
     node_solution = mode_on_nodes(mode, graph)
 
     z_matrix = compute_z_matrix(graph)
@@ -1020,7 +1033,7 @@ def find_threshold_lasing_modes(modes_df, graph, quality_method="eigenvalue"):
 
 def lasing_threshold_linear(mode, graph, D0):
     """Find the linear approximation of the new wavenumber."""
-    graph.graph["params"]["D0"] = D0
+    graph = graph_with_pump(graph, D0)
     return 1.0 / (
         q_value(mode)
         * -1

--- a/netsalt/modes.py
+++ b/netsalt/modes.py
@@ -21,12 +21,12 @@ from .algorithm import (
     find_rough_modes_from_scan,
     refine_mode,
 )
-from .params import NetSaltParams
 from .physics import gamma, q_value
 from .quantum_graph import (
     construct_incidence_matrix,
     construct_laplacian,
     construct_weight_matrix,
+    graph_with_params,
     graph_with_pump,
     mode_quality,
     set_wavenumber,
@@ -99,24 +99,20 @@ class WorkerModes:
         """Call function of the worker."""
         mode = self.estimated_modes[mode_id]
         graph = self.graph
-        params = graph.graph["params"]
         # Apply the per-mode pump / search window / stepsize to a throwaway
         # graph + params copy so the shared graph.graph["params"] is never
-        # mutated in place.
-        if (
-            self.D0s is not None
-            or self.search_radii is not None
-            or self.search_stepsize is not None
-        ):
-            graph = graph.copy()
-            params = params.model_copy() if isinstance(params, NetSaltParams) else dict(params)
-            if self.D0s is not None:
-                params["D0"] = self.D0s[mode_id]
-            if self.search_radii is not None:
-                params.update(self._search_radii_updates(mode))
-            if self.search_stepsize is not None:
-                params["search_stepsize"] = self.search_stepsize
-            graph.graph["params"] = params
+        # mutated in place. One graph copy per mode candidate, which is cheap
+        # next to the eigenvalue refinement that follows.
+        overrides = {}
+        if self.D0s is not None:
+            overrides["D0"] = self.D0s[mode_id]
+        if self.search_radii is not None:
+            overrides.update(self._search_radii_updates(mode))
+        if self.search_stepsize is not None:
+            overrides["search_stepsize"] = self.search_stepsize
+        if overrides:
+            graph = graph_with_params(graph, **overrides)
+        params = graph.graph["params"]
         # Derive a per-mode seed so each call has an independent RNG stream
         # rather than sharing ``self.seed`` across every mode in the pool.
         rng = np.random.default_rng([self.seed, mode_id])

--- a/netsalt/plotting.py
+++ b/netsalt/plotting.py
@@ -12,6 +12,7 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from tqdm import tqdm
 
 from .modes import mean_mode_on_edges, mode_on_nodes
+from .quantum_graph import graph_with_pump
 from .utils import get_scan_grid, linewidth, lorentzian, order_edges_by
 
 L = logging.getLogger(__name__)
@@ -426,7 +427,7 @@ def plot_single_mode(
     """Plot single mode on the graph."""
     mode = modes_df[df_entry][index]
     if df_entry == "threshold_lasing_modes":
-        graph.graph["params"]["D0"] = modes_df["lasing_thresholds"][index]
+        graph = graph_with_pump(graph, modes_df["lasing_thresholds"][index])
     ax = _plot_single_mode(
         graph, mode, ax=ax, colorbar=colorbar, edge_vmin=edge_vmin, edge_vmax=edge_vmax, cmap=cmap
     )
@@ -490,8 +491,7 @@ def plot_mode_evolution(graph, modes_df, index, folder="mode_evolution", ext=".p
     modes = modes_df.loc[index, "mode_trajectories"]
     Path(folder).mkdir(parents=True, exist_ok=True)
     for i, d0 in enumerate(modes.index):
-        graph.graph["params"]["D0"] = d0
-        _plot_single_mode(graph, modes.loc[d0])
+        _plot_single_mode(graph_with_pump(graph, d0), modes.loc[d0])
         plt.suptitle(f"D0={np.around(d0, 3)}")
         plt.savefig(f"{folder}/mode_{index}_D0_{i:03d}{ext}")
         plt.close()
@@ -506,7 +506,7 @@ def plot_line_mode(graph, modes_df, index, df_entry="passive", ax=None):
     mode = modes_df[df_entry][index]
 
     if df_entry == "threshold_lasing_modes":
-        graph.graph["params"]["D0"] = modes_df["lasing_thresholds"][index]
+        graph = graph_with_pump(graph, modes_df["lasing_thresholds"][index])
 
     node_solution = mode_on_nodes(mode, graph)
 

--- a/netsalt/plotting.py
+++ b/netsalt/plotting.py
@@ -382,7 +382,11 @@ def plot_pump_traj(
             if c == "d0":
                 c = modes_df["mode_trajectories"].columns.to_list()
                 if d0s_max is None:
-                    vmax = c[max(np.argmin(abs(np.imag(pumped_modes)), axis=1)) + 1]
+                    # D0 column just past the latest threshold crossing, clamped
+                    # to the last column so a crossing in the final column does
+                    # not index out of range.
+                    threshold_col = max(np.argmin(abs(np.imag(pumped_modes)), axis=1)) + 1
+                    vmax = c[min(threshold_col, len(c) - 1)]
                 else:
                     vmax = d0s_max
             ax.scatter(

--- a/netsalt/quantum_graph.py
+++ b/netsalt/quantum_graph.py
@@ -307,6 +307,34 @@ def set_wavenumber(graph, wavenumber):
     graph.graph["ks"] = graph.graph["dispersion_relation"](wavenumber, params=graph.graph["params"])
 
 
+def graph_with_pump(graph, D0):
+    """Return a shallow copy of ``graph`` whose ``params`` carry pump ``D0``.
+
+    The dispersion relations build the laplacian from ``params["D0"]``. Rather
+    than mutating ``graph.graph["params"]["D0"]`` in place — which leaks the
+    pump amplitude into shared state and imposes a fragile set-then-read
+    ordering on every downstream consumer (``mode_on_nodes``, ``flux_on_edges``,
+    the ``graph.graph["ks"]`` read-backs) — callers that need the laplacian and
+    its derived quantities at a specific pump build them on this throwaway copy.
+
+    Graph structure and node / edge attributes are shared by reference; only
+    ``graph.graph`` is a fresh dict (``nx.Graph.copy`` semantics) with a fresh
+    ``params`` swapped in, so writes to ``params`` / ``ks`` /
+    ``_incidence_topology`` on the copy never touch the original graph.
+
+    Args:
+        graph (graph): quantum graph
+        D0 (float): pump amplitude to set on the copy's params
+    """
+    local = graph.copy()
+    params = graph.graph["params"]
+    if isinstance(params, NetSaltParams):
+        local.graph["params"] = params.model_copy(update={"D0": D0})
+    else:
+        local.graph["params"] = {**params, "D0": D0}
+    return local
+
+
 def _incidence_topology(graph):
     """Precompute the k-independent arrays used by ``construct_incidence_matrix``.
 

--- a/netsalt/quantum_graph.py
+++ b/netsalt/quantum_graph.py
@@ -311,15 +311,15 @@ def set_wavenumber(graph, wavenumber):
     graph.graph["ks"] = graph.graph["dispersion_relation"](wavenumber, params=graph.graph["params"])
 
 
-def graph_with_pump(graph, D0):
-    """Return a shallow copy of ``graph`` whose ``params`` carry pump ``D0``.
+def graph_with_params(graph, **overrides):
+    """Return a shallow copy of ``graph`` with ``params`` field overrides applied.
 
-    The dispersion relations build the laplacian from ``params["D0"]``. Rather
-    than mutating ``graph.graph["params"]["D0"]`` in place — which leaks the
-    pump amplitude into shared state and imposes a fragile set-then-read
-    ordering on every downstream consumer (``mode_on_nodes``, ``flux_on_edges``,
-    the ``graph.graph["ks"]`` read-backs) — callers that need the laplacian and
-    its derived quantities at a specific pump build them on this throwaway copy.
+    Rather than mutating ``graph.graph["params"]`` in place — which leaks values
+    into shared state and imposes a fragile set-then-read ordering on every
+    downstream consumer (``mode_on_nodes``, ``flux_on_edges``, the
+    ``graph.graph["ks"]`` read-backs) — callers that need the laplacian (and its
+    derived quantities) at specific parameter values build them on this
+    throwaway copy.
 
     Graph structure and node / edge attributes are shared by reference; only
     ``graph.graph`` is a fresh dict (``nx.Graph.copy`` semantics) with a fresh
@@ -328,15 +328,27 @@ def graph_with_pump(graph, D0):
 
     Args:
         graph (graph): quantum graph
-        D0 (float): pump amplitude to set on the copy's params
+        **overrides: ``params`` fields to override on the copy (e.g. ``D0=0.7``,
+            ``search_stepsize=0.02``).
     """
     local = graph.copy()
     params = graph.graph["params"]
     if isinstance(params, NetSaltParams):
-        local.graph["params"] = params.model_copy(update={"D0": D0})
+        local.graph["params"] = params.model_copy(update=dict(overrides))
     else:
-        local.graph["params"] = {**params, "D0": D0}
+        local.graph["params"] = {**params, **overrides}
     return local
+
+
+def graph_with_pump(graph, D0):
+    """Return a shallow copy of ``graph`` whose ``params`` carry pump ``D0``.
+
+    Thin wrapper over :func:`graph_with_params`; see it for the copy semantics.
+    The dispersion relations build the laplacian from ``params["D0"]``, so this
+    is how callers evaluate a mode at a specific pump without mutating shared
+    state.
+    """
+    return graph_with_params(graph, D0=D0)
 
 
 def _incidence_topology(graph):
@@ -678,16 +690,17 @@ class QuantumGraph(nx.Graph):
 
         return mode_on_nodes(mode, self)
 
-    # --- structural ops return a NEW graph -> re-wrap to preserve type ---
+    # --- structural ops return a NEW graph (the free functions already return
+    # a subclass-preserving copy when called on a QuantumGraph) ---
     def with_pump(self, D0):
         """Return a copy of this graph whose ``params`` carry pump ``D0``.
 
         Wraps :func:`graph_with_pump`; the original graph is left untouched.
         """
-        return QuantumGraph(graph_with_pump(self, D0))
+        return graph_with_pump(self, D0)
 
     def oversample(self, edge_size):
-        return QuantumGraph(oversample_graph(self, edge_size))
+        return oversample_graph(self, edge_size)
 
     def simplify(self):
-        return QuantumGraph(simplify_graph(self))
+        return simplify_graph(self)

--- a/netsalt/quantum_graph.py
+++ b/netsalt/quantum_graph.py
@@ -528,3 +528,101 @@ def mode_quality(mode, graph, quality_method="eigenvalue", rng=None):
     """
     laplacian = construct_laplacian(to_complex(mode), graph)
     return laplacian_quality(laplacian, method=quality_method, rng=rng)
+
+
+class QuantumGraph(nx.Graph):
+    """A :class:`networkx.Graph` carrying quantum-graph state, with method
+    sugar over the module-level functions.
+
+    This is a *thin, additive* layer requested in issue #28: it lets callers
+    write ``qg.laplacian(k)`` instead of ``construct_laplacian(k, graph)``
+    without threading a bare graph through every call. Because it subclasses
+    ``nx.Graph``, all state still lives in ``graph.graph[...]`` and node / edge
+    attributes, so JSON (``node_link_data``) serialisation, pickling to
+    ``multiprocessing.Pool`` workers, and every existing procedural call site
+    keep working unchanged — a ``QuantumGraph`` *is-a* ``nx.Graph``.
+
+    Build instances with :meth:`from_networkx` (not ``__init__``): the inherited
+    ``nx.Graph.__init__`` is what pickle, ``node_link_graph`` and ``.copy()``
+    use to reconstruct, so it must stay a plain graph constructor.
+
+    Note: this class is ergonomic sugar only. It does not change how
+    ``WorkerModes`` mutates ``graph.graph["params"]`` in place (tracked
+    separately as design debt).
+    """
+
+    @classmethod
+    def from_networkx(
+        cls, graph, params=None, positions=None, lengths=None, seed=42, noise_level=0.001
+    ):
+        """Build a :class:`QuantumGraph` from a plain networkx graph.
+
+        Wraps :func:`create_quantum_graph`; see it for argument semantics.
+        """
+        qg = cls(graph)  # nx.Graph copy-constructor copies structure + all attrs
+        create_quantum_graph(
+            qg,
+            params=params,
+            positions=positions,
+            lengths=lengths,
+            seed=seed,
+            noise_level=noise_level,
+        )
+        return qg
+
+    # --- state accessors (read graph.graph, like the free functions do) ---
+    @property
+    def params(self):
+        """The :class:`~netsalt.params.NetSaltParams` stored on the graph."""
+        return self.graph["params"]
+
+    @property
+    def total_length(self):
+        return get_total_length(self)
+
+    @property
+    def total_inner_length(self):
+        return get_total_inner_length(self)
+
+    # --- setters / mutators (return self for chaining) ---
+    def update_parameters(self, params, force=False):
+        update_parameters(self, params, force=force)
+        return self
+
+    def set_total_length(self, total_length=None, max_extent=None, inner=True, with_position=True):
+        set_total_length(
+            self,
+            total_length=total_length,
+            max_extent=max_extent,
+            inner=inner,
+            with_position=with_position,
+        )
+        return self
+
+    def set_inner_edges(self, params=None, outer_edges=None):
+        set_inner_edges(self, params if params is not None else self.params, outer_edges)
+        return self
+
+    def set_wavenumber(self, wavenumber):
+        set_wavenumber(self, wavenumber)
+        return self
+
+    # --- matrix builders: delegate, reading state off self ---
+    def laplacian(self, wavenumber):
+        return construct_laplacian(wavenumber, self)
+
+    def weight_matrix(self, with_k=True):
+        return construct_weight_matrix(self, with_k=with_k)
+
+    def incidence_matrix(self):
+        return construct_incidence_matrix(self)
+
+    def mode_quality(self, mode, quality_method="eigenvalue", rng=None):
+        return mode_quality(mode, self, quality_method=quality_method, rng=rng)
+
+    # --- structural ops return a NEW graph -> re-wrap to preserve type ---
+    def oversample(self, edge_size):
+        return QuantumGraph(oversample_graph(self, edge_size))
+
+    def simplify(self):
+        return QuantumGraph(simplify_graph(self))

--- a/netsalt/quantum_graph.py
+++ b/netsalt/quantum_graph.py
@@ -12,7 +12,11 @@ import numpy as np
 import scipy as sc
 
 from .params import NetSaltParams
-from .physics import update_params_dielectric_constant
+from .physics import (
+    set_dielectric_constant,
+    set_dispersion_relation,
+    update_params_dielectric_constant,
+)
 from .utils import to_complex
 
 L = logging.getLogger(__name__)
@@ -574,9 +578,13 @@ class QuantumGraph(nx.Graph):
     ``nx.Graph.__init__`` is what pickle, ``node_link_graph`` and ``.copy()``
     use to reconstruct, so it must stay a plain graph constructor.
 
-    Note: this class is ergonomic sugar only. It does not change how
-    ``WorkerModes`` mutates ``graph.graph["params"]`` in place (tracked
-    separately as design debt).
+    The methods cover the common workflow on a single object — set up physics
+    (:meth:`set_dispersion_relation`, :meth:`set_dielectric_constant`), build
+    matrices (:meth:`laplacian`, :meth:`weight_matrix`, :meth:`incidence_matrix`),
+    evaluate quality (:meth:`mode_quality`), and run the scan/solve
+    (:meth:`scan_frequencies`, :meth:`mode_on_nodes`). Each one delegates to the
+    existing free function, so behaviour is identical; the class is ergonomic
+    sugar only.
     """
 
     @classmethod
@@ -611,6 +619,15 @@ class QuantumGraph(nx.Graph):
     @property
     def total_inner_length(self):
         return get_total_inner_length(self)
+
+    # --- physics setup (return self for chaining) ---
+    def set_dispersion_relation(self, dispersion_relation):
+        set_dispersion_relation(self, dispersion_relation)
+        return self
+
+    def set_dielectric_constant(self, custom_values=None, rng=None):
+        set_dielectric_constant(self, self.params, custom_values=custom_values, rng=rng)
+        return self
 
     # --- setters / mutators (return self for chaining) ---
     def update_parameters(self, params, force=False):
@@ -648,7 +665,27 @@ class QuantumGraph(nx.Graph):
     def mode_quality(self, mode, quality_method="eigenvalue", rng=None):
         return mode_quality(mode, self, quality_method=quality_method, rng=rng)
 
+    # --- mode search / solve (lazy imports: modes imports this module) ---
+    def scan_frequencies(self, quality_method="eigenvalue"):
+        """Scan the complex-frequency grid and return the quality matrix."""
+        from .modes import scan_frequencies
+
+        return scan_frequencies(self, quality_method=quality_method)
+
+    def mode_on_nodes(self, mode):
+        """Return the mode field evaluated on the graph nodes."""
+        from .modes import mode_on_nodes
+
+        return mode_on_nodes(mode, self)
+
     # --- structural ops return a NEW graph -> re-wrap to preserve type ---
+    def with_pump(self, D0):
+        """Return a copy of this graph whose ``params`` carry pump ``D0``.
+
+        Wraps :func:`graph_with_pump`; the original graph is left untouched.
+        """
+        return QuantumGraph(graph_with_pump(self, D0))
+
     def oversample(self, edge_size):
         return QuantumGraph(oversample_graph(self, edge_size))
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -21,6 +21,52 @@ from netsalt.utils import (
 )
 
 
+def make_line_graph(
+    n_edges=5,
+    dielectric=4.0,
+    extra_params=None,
+    normalized_positions=False,
+    total_length=None,
+    as_class=False,
+):
+    """Shared builder for the open dielectric line-graph fixture.
+
+    A path graph with unit (or, with ``normalized_positions``, [0, 1]-scaled)
+    edge lengths, a uniform dielectric, and the dielectric dispersion relation
+    set. ``extra_params`` merges extra knobs into the params dict;
+    ``as_class=True`` returns a :class:`~netsalt.quantum_graph.QuantumGraph`.
+    """
+    import netsalt
+    from netsalt.physics import dispersion_relation_dielectric
+    from netsalt.quantum_graph import QuantumGraph, create_quantum_graph, set_total_length
+
+    denom = n_edges if normalized_positions else 1
+    positions = np.array([[float(i) / denom, 0.0] for i in range(n_edges + 1)])
+    params = {
+        "open_model": "open",
+        "dielectric_params": {
+            "method": "uniform",
+            "inner_value": dielectric,
+            "loss": 0.0,
+            "outer_value": 1.0,
+        },
+        "c": 1.0,
+    }
+    if extra_params:
+        params.update(extra_params)
+
+    g = nx.path_graph(n_edges + 1)
+    if as_class:
+        g = QuantumGraph.from_networkx(g, params=params, positions=positions)
+    else:
+        create_quantum_graph(g, params, positions=positions)
+    if total_length is not None:
+        set_total_length(g, total_length)
+    netsalt.set_dispersion_relation(g, dispersion_relation_dielectric)
+    netsalt.set_dielectric_constant(g, g.graph["params"])
+    return g
+
+
 class TestComplexConversion:
     def test_to_complex_uses_minus_imag_convention(self):
         # netsalt stores a mode as [k, alpha] with alpha = -imag(k)
@@ -257,27 +303,8 @@ class TestComputeCore:
     """Smoke + structural tests for the compute primitives."""
 
     def _line_graph(self, n_edges=5, dielectric=4.0):
-        """3-node line graph with unit edge lengths and a constant dispersion."""
-        import netsalt
-        from netsalt.physics import dispersion_relation_dielectric
-        from netsalt.quantum_graph import create_quantum_graph
-
-        g = nx.path_graph(n_edges + 1)
-        positions = np.array([[float(i), 0.0] for i in range(n_edges + 1)])
-        params = {
-            "open_model": "open",
-            "dielectric_params": {
-                "method": "uniform",
-                "inner_value": dielectric,
-                "loss": 0.0,
-                "outer_value": 1.0,
-            },
-            "c": 1.0,
-        }
-        create_quantum_graph(g, params, positions=positions)
-        netsalt.set_dispersion_relation(g, dispersion_relation_dielectric)
-        netsalt.set_dielectric_constant(g, g.graph["params"])
-        return g
+        """Open dielectric line graph with unit edge lengths."""
+        return make_line_graph(n_edges, dielectric)
 
     def test_construct_laplacian_is_square(self):
         from netsalt.quantum_graph import construct_laplacian
@@ -524,36 +551,22 @@ class TestRefinementAlgorithms:
     guess; the dispatcher picks the one named in ``params``."""
 
     def _line_graph(self, n_edges=6, dielectric=4.0):
-        import netsalt
-        from netsalt.physics import dispersion_relation_dielectric
-        from netsalt.quantum_graph import create_quantum_graph
-
-        g = nx.path_graph(n_edges + 1)
-        positions = np.array([[float(i), 0.0] for i in range(n_edges + 1)])
-        params = {
-            "open_model": "open",
-            "dielectric_params": {
-                "method": "uniform",
-                "inner_value": dielectric,
-                "loss": 0.0,
-                "outer_value": 1.0,
+        return make_line_graph(
+            n_edges,
+            dielectric,
+            extra_params={
+                "quality_threshold": 1e-4,
+                "search_stepsize": 0.05,
+                "max_steps": 500,
+                # ``_search_box`` uses these to build the locality bound; set a
+                # generous window around the mode we're targeting so the
+                # refiners can actually move to the root.
+                "k_min": 2.8,
+                "k_max": 3.4,
+                "alpha_min": 0.0,
+                "alpha_max": 0.3,
             },
-            "c": 1.0,
-            "quality_threshold": 1e-4,
-            "search_stepsize": 0.05,
-            "max_steps": 500,
-            # ``_search_box`` uses these to build the locality bound; set a
-            # generous window around the mode we're targeting so the refiners
-            # can actually move to the root.
-            "k_min": 2.8,
-            "k_max": 3.4,
-            "alpha_min": 0.0,
-            "alpha_max": 0.3,
-        }
-        create_quantum_graph(g, params, positions=positions)
-        netsalt.set_dispersion_relation(g, dispersion_relation_dielectric)
-        netsalt.set_dielectric_constant(g, g.graph["params"])
-        return g
+        )
 
     def _count_evals(self, fn, *args, **kwargs):
         """Monkey-patch ``mode_quality`` to count evaluations inside *fn*."""
@@ -677,31 +690,13 @@ class TestContourIntegration:
     handles regions where the mode count exceeds the probe dimension."""
 
     def _line_graph(self, n_edges=10, dielectric=4.0, total_length=1.0):
-        import netsalt
-        from netsalt.physics import dispersion_relation_dielectric
-        from netsalt.quantum_graph import create_quantum_graph, set_total_length
-
-        g = nx.path_graph(n_edges + 1)
-        positions = np.array([[float(i) / n_edges, 0.0] for i in range(n_edges + 1)])
-        params = {
-            "open_model": "open",
-            "dielectric_params": {
-                "method": "uniform",
-                "inner_value": dielectric,
-                "loss": 0.0,
-                "outer_value": 1.0,
-            },
-            "c": 1.0,
-            "k_min": 0.5,
-            "k_max": 20.0,
-            "alpha_min": 0.0,
-            "alpha_max": 1.0,
-        }
-        create_quantum_graph(g, params, positions=positions)
-        set_total_length(g, total_length)
-        netsalt.set_dispersion_relation(g, dispersion_relation_dielectric)
-        netsalt.set_dielectric_constant(g, g.graph["params"])
-        return g
+        return make_line_graph(
+            n_edges,
+            dielectric,
+            extra_params={"k_min": 0.5, "k_max": 20.0, "alpha_min": 0.0, "alpha_max": 1.0},
+            normalized_positions=True,
+            total_length=total_length,
+        )
 
     def test_contour_finds_true_modes_on_line_graph(self):
         """On the dielectric line graph, Beyn should return *true* roots
@@ -1186,26 +1181,7 @@ class TestQuantumGraph:
 
     def _qg(self, n_edges=4, dielectric=4.0):
         """Build a QuantumGraph line graph with a dispersion relation set."""
-        import netsalt
-        from netsalt.physics import dispersion_relation_dielectric
-        from netsalt.quantum_graph import QuantumGraph
-
-        g = nx.path_graph(n_edges + 1)
-        positions = np.array([[float(i), 0.0] for i in range(n_edges + 1)])
-        params = {
-            "open_model": "open",
-            "dielectric_params": {
-                "method": "uniform",
-                "inner_value": dielectric,
-                "loss": 0.0,
-                "outer_value": 1.0,
-            },
-            "c": 1.0,
-        }
-        qg = QuantumGraph.from_networkx(g, params=params, positions=positions)
-        netsalt.set_dispersion_relation(qg, dispersion_relation_dielectric)
-        netsalt.set_dielectric_constant(qg, qg.graph["params"])
-        return qg
+        return make_line_graph(n_edges, dielectric, as_class=True)
 
     def test_is_nx_graph_subclass_with_params(self):
         import networkx as nx_
@@ -1295,6 +1271,11 @@ class TestQuantumGraph:
         assert isinstance(over, QuantumGraph)
         assert len(over) > len(qg)
 
+    def test_simplify_returns_quantum_graph(self):
+        from netsalt.quantum_graph import QuantumGraph
+
+        assert isinstance(self._qg().simplify(), QuantumGraph)
+
     def test_physics_setup_methods_chain(self):
         """set_dispersion_relation / set_dielectric_constant return self and
         set the same graph state as the free functions."""
@@ -1368,32 +1349,13 @@ class TestNoInPlacePumpMutation:
     """Regression for the WorkerModes in-place params mutation: applying a
     per-mode pump (D0) or search window must never leak into the shared
     ``graph.graph["params"]``. The laplacian-at-D0 is built on a throwaway
-    copy via ``graph_with_pump`` instead."""
+    copy via ``graph_with_params`` instead."""
 
     def _line_graph(self, n_edges=4):
-        import netsalt
-        from netsalt.physics import dispersion_relation_dielectric
-        from netsalt.quantum_graph import create_quantum_graph
-
-        g = nx.path_graph(n_edges + 1)
-        positions = np.array([[float(i), 0.0] for i in range(n_edges + 1)])
-        params = {
-            "open_model": "open",
-            "dielectric_params": {
-                "method": "uniform",
-                "inner_value": 4.0,
-                "loss": 0.0,
-                "outer_value": 1.0,
-            },
-            "c": 1.0,
-            "refine_method": "root",
-            "quality_threshold": 1e-2,
-            "max_steps": 5,
-        }
-        create_quantum_graph(g, params, positions=positions)
-        netsalt.set_dispersion_relation(g, dispersion_relation_dielectric)
-        netsalt.set_dielectric_constant(g, g.graph["params"])
-        return g
+        return make_line_graph(
+            n_edges,
+            extra_params={"refine_method": "root", "quality_threshold": 1e-2, "max_steps": 5},
+        )
 
     def test_graph_with_pump_leaves_original_untouched(self):
         from netsalt.quantum_graph import graph_with_pump

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1177,3 +1177,46 @@ class TestRngIsolation:
         ws.quality_method = "eigenvalue"
         ws.rng = np.random.default_rng(42)
         assert isinstance(ws.rng, np.random.Generator)
+
+
+class TestPlotPumpTraj:
+    """Regression tests for ``plot_pump_traj`` (issues #17 / #25).
+
+    The colorbar ``vmax`` was computed as ``c[max(argmin(|imag|)) + 1]``.
+    When a mode's |imag| minimum lands in the *last* D0 column the ``+ 1``
+    indexed past the end of the column list and raised
+    ``IndexError: list index out of range``.
+    """
+
+    def _modes_df(self, imag_per_step, n_modes=2):
+        """Build a minimal modes_df with a ``mode_trajectories`` block.
+
+        ``imag_per_step`` is the imaginary part of every mode at each D0
+        column, so the caller controls where ``argmin(|imag|)`` lands.
+        """
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import pandas as pd
+
+        D0s = [0.1 * j for j in range(len(imag_per_step))]
+        df = pd.DataFrame()
+        for D0, im in zip(D0s, imag_per_step, strict=True):
+            df["mode_trajectories", D0] = [complex(1.0, im) for _ in range(n_modes)]
+        df.columns = pd.MultiIndex.from_tuples(df.columns)
+        return df
+
+    def test_threshold_in_last_column_does_not_raise(self):
+        from netsalt.plotting import plot_pump_traj
+
+        # |imag| strictly decreasing -> argmin is the final column.
+        df = self._modes_df([1.0, 0.5, 0.0])
+        # Must not raise IndexError.
+        plot_pump_traj(df)
+
+    def test_threshold_in_middle_column(self):
+        from netsalt.plotting import plot_pump_traj
+
+        # |imag| minimal in the middle column -> +1 stays in range.
+        df = self._modes_df([1.0, 0.0, 1.0])
+        plot_pump_traj(df)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1296,6 +1296,72 @@ class TestQuantumGraph:
         assert len(over) > len(qg)
 
 
+class TestNoInPlacePumpMutation:
+    """Regression for the WorkerModes in-place params mutation: applying a
+    per-mode pump (D0) or search window must never leak into the shared
+    ``graph.graph["params"]``. The laplacian-at-D0 is built on a throwaway
+    copy via ``graph_with_pump`` instead."""
+
+    def _line_graph(self, n_edges=4):
+        import netsalt
+        from netsalt.physics import dispersion_relation_dielectric
+        from netsalt.quantum_graph import create_quantum_graph
+
+        g = nx.path_graph(n_edges + 1)
+        positions = np.array([[float(i), 0.0] for i in range(n_edges + 1)])
+        params = {
+            "open_model": "open",
+            "dielectric_params": {
+                "method": "uniform",
+                "inner_value": 4.0,
+                "loss": 0.0,
+                "outer_value": 1.0,
+            },
+            "c": 1.0,
+            "refine_method": "root",
+            "quality_threshold": 1e-2,
+            "max_steps": 5,
+        }
+        create_quantum_graph(g, params, positions=positions)
+        netsalt.set_dispersion_relation(g, dispersion_relation_dielectric)
+        netsalt.set_dielectric_constant(g, g.graph["params"])
+        return g
+
+    def test_graph_with_pump_leaves_original_untouched(self):
+        from netsalt.quantum_graph import graph_with_pump
+
+        g = self._line_graph()
+        assert g.graph["params"].get("D0") is None
+        local = graph_with_pump(g, 0.7)
+        # the copy carries the pump...
+        assert local.graph["params"]["D0"] == 0.7
+        # ...the original does not, and it is a distinct params object
+        assert g.graph["params"].get("D0") is None
+        assert local.graph["params"] is not g.graph["params"]
+
+    def test_worker_modes_does_not_mutate_shared_params(self):
+        from netsalt.modes import WorkerModes
+
+        g = self._line_graph()
+        assert g.graph["params"].get("D0") is None
+        assert g.graph["params"].get("k_min") is None
+
+        worker = WorkerModes(
+            [[1.0, 0.0], [1.2, 0.0]],
+            g,
+            D0s=[0.5, 0.6],
+            search_radii=[0.1, 0.1],
+            quality_method="eigenvalue",
+        )
+        worker(0)
+        worker(1)
+
+        # No D0 or search-window field leaked back onto the shared params.
+        assert g.graph["params"].get("D0") is None
+        assert g.graph["params"].get("k_min") is None
+        assert g.graph["params"].get("k_max") is None
+
+
 class TestPlotPumpTraj:
     """Regression tests for ``plot_pump_traj`` (issues #17 / #25).
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1047,7 +1047,7 @@ class TestContourIntegration:
 
 
 class TestPumpCostAndOverlap:
-    """Exercise ``pump.py`` helpers that don't need a full Luigi pipeline."""
+    """Exercise ``pump.py`` helpers that don't need a full pipeline."""
 
     def _tiny_graph_with_modes(self):
         """Return a (graph, modes_df) pair ready for pump helpers."""

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1179,6 +1179,123 @@ class TestRngIsolation:
         assert isinstance(ws.rng, np.random.Generator)
 
 
+class TestQuantumGraph:
+    """The QuantumGraph class (issue #28) is a thin, additive nx.Graph subclass:
+    its methods must delegate to the existing free functions, and it must remain
+    picklable and JSON-serialisable exactly like a plain quantum graph."""
+
+    def _qg(self, n_edges=4, dielectric=4.0):
+        """Build a QuantumGraph line graph with a dispersion relation set."""
+        import netsalt
+        from netsalt.physics import dispersion_relation_dielectric
+        from netsalt.quantum_graph import QuantumGraph
+
+        g = nx.path_graph(n_edges + 1)
+        positions = np.array([[float(i), 0.0] for i in range(n_edges + 1)])
+        params = {
+            "open_model": "open",
+            "dielectric_params": {
+                "method": "uniform",
+                "inner_value": dielectric,
+                "loss": 0.0,
+                "outer_value": 1.0,
+            },
+            "c": 1.0,
+        }
+        qg = QuantumGraph.from_networkx(g, params=params, positions=positions)
+        netsalt.set_dispersion_relation(qg, dispersion_relation_dielectric)
+        netsalt.set_dielectric_constant(qg, qg.graph["params"])
+        return qg
+
+    def test_is_nx_graph_subclass_with_params(self):
+        import networkx as nx_
+
+        from netsalt.params import NetSaltParams
+
+        qg = self._qg()
+        assert isinstance(qg, nx_.Graph)
+        assert isinstance(qg.params, NetSaltParams)
+
+    def test_matrix_methods_match_free_functions(self):
+        """Methods are sugar: they must return exactly what the free functions
+        return on the same graph."""
+        from netsalt.quantum_graph import (
+            construct_incidence_matrix,
+            construct_laplacian,
+            construct_weight_matrix,
+            mode_quality,
+        )
+
+        qg = self._qg()
+        k = 1.0 + 0.0j
+
+        assert np.allclose(qg.laplacian(k).toarray(), construct_laplacian(k, qg).toarray())
+        assert np.allclose(qg.weight_matrix().toarray(), construct_weight_matrix(qg).toarray())
+        bt_m, b_m = qg.incidence_matrix()
+        bt_f, b_f = construct_incidence_matrix(qg)
+        assert np.allclose(bt_m.toarray(), bt_f.toarray())
+        assert np.allclose(b_m.toarray(), b_f.toarray())
+
+        mode = [1.0, 0.0]
+        q_method = qg.mode_quality(mode, rng=np.random.default_rng(0))
+        q_func = mode_quality(mode, qg, rng=np.random.default_rng(0))
+        assert q_method == q_func
+
+    def test_total_length_properties(self):
+        from netsalt.quantum_graph import get_total_length
+
+        qg = self._qg()
+        assert qg.total_length == get_total_length(qg)
+
+    def test_pickle_round_trip_preserves_type_state_and_methods(self):
+        """WorkerScan/WorkerModes pickle the whole graph into Pool workers, so
+        the subclass must survive a pickle round-trip with its state intact."""
+        import pickle
+
+        from netsalt.quantum_graph import QuantumGraph
+
+        qg = self._qg()
+        restored = pickle.loads(pickle.dumps(qg))
+        assert isinstance(restored, QuantumGraph)
+        assert restored.params["open_model"] == "open"
+        # a delegating method still works on the unpickled instance
+        assert restored.laplacian(1.0 + 0.0j).shape == (len(qg), len(qg))
+
+    def test_json_round_trip_as_class(self, tmp_path):
+        from netsalt.io import load_graph, save_graph
+        from netsalt.quantum_graph import QuantumGraph
+
+        qg = self._qg()
+        path = tmp_path / "qg.json"
+        save_graph(qg, str(path))
+
+        loaded = load_graph(str(path), as_class=True)
+        assert isinstance(loaded, QuantumGraph)
+        assert loaded.params["open_model"] == qg.params["open_model"]
+        assert np.allclose(loaded.graph["lengths"], qg.graph["lengths"])
+        assert np.allclose(loaded.nodes[0]["position"], qg.nodes[0]["position"])
+
+    def test_load_graph_defaults_to_plain_graph(self, tmp_path):
+        """as_class defaults to False so existing callers are unaffected."""
+        from netsalt.io import load_graph, save_graph
+        from netsalt.quantum_graph import QuantumGraph
+
+        qg = self._qg()
+        path = tmp_path / "qg.json"
+        save_graph(qg, str(path))
+
+        loaded = load_graph(str(path))
+        assert not isinstance(loaded, QuantumGraph)
+
+    def test_oversample_returns_quantum_graph(self):
+        from netsalt.quantum_graph import QuantumGraph
+
+        qg = self._qg()
+        over = qg.oversample(0.3)
+        assert isinstance(over, QuantumGraph)
+        assert len(over) > len(qg)
+
+
 class TestPlotPumpTraj:
     """Regression tests for ``plot_pump_traj`` (issues #17 / #25).
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1414,20 +1414,24 @@ class TestNoInPlacePumpMutation:
         assert g.graph["params"].get("D0") is None
         assert g.graph["params"].get("k_min") is None
 
+        assert g.graph["params"].get("search_stepsize") is None
+
         worker = WorkerModes(
             [[1.0, 0.0], [1.2, 0.0]],
             g,
             D0s=[0.5, 0.6],
             search_radii=[0.1, 0.1],
+            search_stepsize=0.02,
             quality_method="eigenvalue",
         )
         worker(0)
         worker(1)
 
-        # No D0 or search-window field leaked back onto the shared params.
+        # No D0 / search-window / stepsize field leaked back onto shared params.
         assert g.graph["params"].get("D0") is None
         assert g.graph["params"].get("k_min") is None
         assert g.graph["params"].get("k_max") is None
+        assert g.graph["params"].get("search_stepsize") is None
 
 
 class TestPlotPumpTraj:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1295,6 +1295,74 @@ class TestQuantumGraph:
         assert isinstance(over, QuantumGraph)
         assert len(over) > len(qg)
 
+    def test_physics_setup_methods_chain(self):
+        """set_dispersion_relation / set_dielectric_constant return self and
+        set the same graph state as the free functions."""
+        from netsalt.physics import dispersion_relation_dielectric
+        from netsalt.quantum_graph import QuantumGraph
+
+        g = nx.path_graph(4)
+        positions = np.array([[float(i), 0.0] for i in range(4)])
+        params = {
+            "open_model": "open",
+            "dielectric_params": {
+                "method": "uniform",
+                "inner_value": 4.0,
+                "loss": 0.0,
+                "outer_value": 1.0,
+            },
+            "c": 1.0,
+        }
+        qg = QuantumGraph.from_networkx(g, params=params, positions=positions)
+        out = qg.set_dispersion_relation(dispersion_relation_dielectric).set_dielectric_constant()
+        assert out is qg  # chainable
+        assert qg.graph["dispersion_relation"] is dispersion_relation_dielectric
+        assert qg.params.get("dielectric_constant") is not None
+        # parity: a laplacian is now buildable, matching the free function
+        from netsalt.quantum_graph import construct_laplacian
+
+        assert np.allclose(
+            qg.laplacian(1.0 + 0.0j).toarray(), construct_laplacian(1.0 + 0.0j, qg).toarray()
+        )
+
+    def test_with_pump_returns_quantum_graph_without_mutating(self):
+        from netsalt.quantum_graph import QuantumGraph
+
+        qg = self._qg()
+        assert qg.params.get("D0") is None
+        pumped = qg.with_pump(0.7)
+        assert isinstance(pumped, QuantumGraph)
+        assert pumped.params["D0"] == 0.7
+        assert qg.params.get("D0") is None  # original untouched
+
+    def test_mode_on_nodes_matches_free_function(self):
+        from netsalt.modes import mode_on_nodes
+
+        qg = self._qg()
+        qg.params["quality_threshold"] = 1e6  # relax so mode_on_nodes never raises
+        mode = [1.0, 0.0]
+        assert np.allclose(qg.mode_on_nodes(mode), mode_on_nodes(mode, qg))
+
+    def test_scan_frequencies_matches_free_function(self):
+        from netsalt.modes import scan_frequencies
+
+        qg = self._qg()
+        qg.params.update(
+            {
+                "k_min": 1.0,
+                "k_max": 1.2,
+                "k_n": 2,
+                "alpha_min": 0.0,
+                "alpha_max": 0.1,
+                "alpha_n": 2,
+                "n_workers": 1,
+            }
+        )
+        method = qg.scan_frequencies()
+        free = scan_frequencies(qg)
+        assert method.shape == (2, 2)
+        assert np.allclose(method, free)
+
 
 class TestNoInPlacePumpMutation:
     """Regression for the WorkerModes in-place params mutation: applying a


### PR DESCRIPTION
Rebased on `master` (post #39, the Luigi → `netsalt.pipeline` migration). Bundles three issue fixes plus follow-on refactors and docs.

## 1. Fix `IndexError` in `plot_pump_traj` (closes #17, closes #25)

Both issues are the same bug. The colorbar `vmax` was `c[max(np.argmin(abs(np.imag(pumped_modes)), axis=1)) + 1]`; when a mode's threshold crossing lands in the **last** D0 column, `+ 1` indexes past the end. Fixed by clamping to the last column.

## 2. Add `QuantumGraph` class (closes #28)

A **thin, additive** `class QuantumGraph(nx.Graph)` giving method-style ergonomics instead of threading a bare graph through free functions:

```python
qg = QuantumGraph.from_networkx(g, params, positions=positions)
qg.set_dispersion_relation(dispersion_relation_dielectric).set_dielectric_constant()
L = qg.laplacian(k); q = qg.mode_quality(mode); pumped = qg.with_pump(0.7)
qualities = qg.scan_frequencies()
```

- Subclassing `nx.Graph` keeps all state in `graph.graph[...]` / node / edge attrs, so `node_link_data` JSON serialization, pickling to `multiprocessing.Pool` workers, and every existing procedural call site keep working **unchanged**.
- Built via `from_networkx`; `__init__` stays `nx.Graph.__init__` so pickle / `node_link_graph` / `.copy()` reconstruct correctly.
- `load_graph(..., as_class=False)` opt-in returns a `QuantumGraph` from the JSON path; default preserves plain-graph behaviour.
- Methods delegate to the free functions (`construct_laplacian`, `mode_quality`, …); `scan_frequencies`/`mode_on_nodes` lazy-import from `modes` to avoid the cycle.

## 3. Decouple per-mode pump (D0) / search window / stepsize from shared params

`WorkerModes` (and `pump_linear`, `_precomputations_mode_competition`, `lasing_threshold_linear`, and the plotting lasing-mode helpers) used to stash `D0` / search window / `search_stepsize` by mutating `graph.graph["params"]` **in place**, relying on downstream code reading them back. New `graph_with_params(graph, **overrides)` (with a `graph_with_pump` shortcut) returns a shallow copy carrying the overrides; every stash now builds on that throwaway copy, so the shared params are never mutated during a compute.

**Behaviour unchanged**: the functional test (`compute_lasing_modes` byte-diff, exercising the pump-trajectory / threshold / mode-competition paths) passes byte-identical, including after the rebase onto master's regenerated fixtures.

## 4. Review follow-ups

A high-effort code review (7 finder angles) found **no correctness bugs**. Applied the cleanups it surfaced: unified the graph-copy logic into one `graph_with_params` helper (used by both `graph_with_pump` and `WorkerModes`), dropped a redundant double graph-copy in `with_pump`/`oversample`/`simplify`, and collapsed five near-identical line-graph test builders into one `make_line_graph(...)` helper.

## 5. Docs

- README: new Quickstart with a runnable `QuantumGraph` example and the pipeline CLI.
- `doc/source/index.rst`: modernised Installation (uv + PyPI) and Usage (object API + pipeline); dropped the stale "no PyPi / scripts 0 to 0" placeholders.
- `doc/source/quantum_graph.rst`: leads with the `QuantumGraph` / `graph_with_params` overview.
- Updated stale Luigi references in README/docstrings to the pipeline (kept the historical/migration ones in `MIGRATION.md` etc.).
- Docs build clean under `sphinx-build -W`.

## Tests

`TestPlotPumpTraj`, `TestQuantumGraph` (delegation parity, subclassing, pickle + JSON round-trips, physics chaining, `with_pump`, `mode_on_nodes`, `scan_frequencies`, `oversample`/`simplify`), and `TestNoInPlacePumpMutation` (no D0 / search window / stepsize leaks). Full suite **91 passed**, ruff check + format clean.

https://claude.ai/code/session_01EH6xEV2sQozKjjH6vNKjyC